### PR TITLE
Minor fixes for WeasyPrint

### DIFF
--- a/lessons/Makefile
+++ b/lessons/Makefile
@@ -10,7 +10,7 @@ antennahouse:
 	-run.sh -d  index.html -o antennahouse.pdf
 
 weasyprint:
-	-weasyprint  index.html weasyprint.pdf
+	-weasyprint  -e utf-8 index.html weasyprint.pdf
 
 
 clean:

--- a/lessons/lesson-hyphenation-long-words/styles.css
+++ b/lessons/lesson-hyphenation-long-words/styles.css
@@ -27,6 +27,7 @@ p.hyphenate {
     border: 1px solid grey;
     hyphenate-before: 4;
     hyphenate-after: 3;
+    hyphenate-limit-chars: 1 4 3;
     hyphens: auto;
     -epub-hyphens: auto;
     -webkit-hyphens: auto;

--- a/lessons/lesson-ligatures/styles.css
+++ b/lessons/lesson-ligatures/styles.css
@@ -15,12 +15,14 @@ div.demo {
 }
 
 .with-ligatures {
+    font-variant-ligatures: normal;
     -ah-ligature-mode: auto;
     -webkit-font-kerning: auto;
 }
 
 
 .without-ligatures {
+    font-variant-ligatures: none;
     -ah-ligature-mode: none;
 }
 

--- a/lessons/lesson-named-pages/styles.css
+++ b/lessons/lesson-named-pages/styles.css
@@ -14,7 +14,7 @@ h1 {
 }
 
 @page Bizarre {
-    size: a5 landscape;
+    size: 148mm 105mm;
     background: blue;
     color: pink;
     border: 3px dashed yellow;

--- a/lessons/lesson-page-areas/styles.css
+++ b/lessons/lesson-page-areas/styles.css
@@ -95,4 +95,7 @@
     prince-bleed: 10mm;
     marks: crop cross;
 
+    /* WeasyPrint */
+    bleed: 10mm;
+
 }


### PR DESCRIPTION
This pull request has 3 commits that you can cherry-pick or merge, as you want.

- Force UTF-8 encoding for WeasyPrint, as some tests (at least [lesson-hyphenation-long-words](https://www.print-css.rocks/lesson/lesson-hyphenation-long-words)) have no explicit charset.
- Add standard CSS properties where proprietary or nonstandard properties are used.
- Fix page size for one test where page text differs from real page format.

Related to Kozea/WeasyPrint#1026.